### PR TITLE
Add cli command to find default browser on mac os

### DIFF
--- a/core/src/main/java/net/brlns/gdownloader/GDownloader.java
+++ b/core/src/main/java/net/brlns/gdownloader/GDownloader.java
@@ -566,7 +566,14 @@ public final class GDownloader{
                         }
                     }
                 }else if(os.contains("mac")){
-                    browserName = "safari";//hstr0100 does not have a mac to figure out how to implement this.
+                    List<String> output = readOutput(
+                            "bash",
+                            "-c",
+                            "defaults read ~/Library/Preferences/com.apple.LaunchServices/com.apple.launchservices.secure | awk -F '\"' '/http;/{print window[(NR)-1]}{window[NR]=$2}'");
+
+                    log.info("Default browser: {}", output);
+
+                    browserName = output.getFirst();
                 }else if(os.contains("nix") || os.contains("nux")){
                     List<String> output = readOutput("xdg-settings", "get", "default-web-browser");
 


### PR DESCRIPTION
Added a method to determine the default browser on macOS. The command returns an identifier in the format `com.vendor.browsername` (e.g., `com.apple.safari`).

Tested on macOS Monterey 12.4